### PR TITLE
add hiragana and katagana into dRemaps

### DIFF
--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -6082,9 +6082,9 @@ CSphTokenizer_UTF8<IS_QUERY>::CSphTokenizer_UTF8 ()
     // 3040 - 30ff Hiragana/Katagana
     // ff00 - ffff half/fullwidth forms
     CSphVector<CSphRemapRange> dRemaps;
-    dRemaps.Add ( CSphRemapRange ( 0x4e00, 0x9FFF, 0x4e00 ) );
-    dRemaps.Add ( CSphRemapRange ( 0xFF00, 0xFFFF, 0xFF00 ) );
-    dRemaps.Add ( CSphRemapRange ( 0x3000, 0x30FF, 0x3000 ) );
+    dRemaps.Add ( CSphRemapRange ( 0x4E00, 0x9FFF, 0x4E00 ) );
+    dRemaps.Add ( CSphRemapRange ( 0xFF10, 0xFFFF, 0xFF10 ) );
+    dRemaps.Add ( CSphRemapRange ( 0x3040, 0x30FF, 0x3040 ) );
 
     m_tLC.AddRemaps ( dRemaps,
         FLAG_CODEPOINT_NGRAM ); // !COMMIT support other n-gram lengths than 1
@@ -6566,9 +6566,9 @@ CSphTokenizer_UTF8MMSeg<IS_QUERY>::CSphTokenizer_UTF8MMSeg ()
 {
     //over ride charmap
     CSphVector<CSphRemapRange> dRemaps;
-    dRemaps.Add ( CSphRemapRange ( 0x4e00, 0x9FFF, 0x4e00 ) );
-    dRemaps.Add ( CSphRemapRange ( 0xFF00, 0xFFFF, 0xFF00 ) );
-    dRemaps.Add ( CSphRemapRange ( 0x3000, 0x30FF, 0x3000 ) );
+    dRemaps.Add ( CSphRemapRange ( 0x4E00, 0x9FFF, 0x4E00 ) );
+    dRemaps.Add ( CSphRemapRange ( 0xFF10, 0xFFFF, 0xFF10 ) );
+    dRemaps.Add ( CSphRemapRange ( 0x3040, 0x30FF, 0x3040 ) );
 
     CSphTokenizer_UTF8<IS_QUERY>::m_tLC.AddRemaps ( dRemaps,
         FLAG_CODEPOINT_NGRAM | FLAG_CODEPOINT_SPECIAL); // !COMMIT support other n-gram lengths than 1

--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -6077,10 +6077,14 @@ CSphTokenizer_UTF8<IS_QUERY>::CSphTokenizer_UTF8 ()
 
     // BEGIN CJK There is no case folding, should do this in remote tokenizer.
     // Here just make CJK Charactor will remain. --coreseek
+    // 4e00 - 9fff CJK unified ideographs
+    // 3000 - 303f CJK symbols and punctuation
+    // 3040 - 30ff Hiragana/Katagana
+    // ff00 - ffff half/fullwidth forms
     CSphVector<CSphRemapRange> dRemaps;
-    dRemaps.Add ( CSphRemapRange ( 0x4e00, 0x9fff, 0x4e00 ) );
+    dRemaps.Add ( CSphRemapRange ( 0x4e00, 0x9FFF, 0x4e00 ) );
     dRemaps.Add ( CSphRemapRange ( 0xFF00, 0xFFFF, 0xFF00 ) );
-    dRemaps.Add ( CSphRemapRange ( 0x3000, 0x303F, 0x3000 ) );
+    dRemaps.Add ( CSphRemapRange ( 0x3000, 0x30FF, 0x3000 ) );
 
     m_tLC.AddRemaps ( dRemaps,
         FLAG_CODEPOINT_NGRAM ); // !COMMIT support other n-gram lengths than 1
@@ -6562,9 +6566,9 @@ CSphTokenizer_UTF8MMSeg<IS_QUERY>::CSphTokenizer_UTF8MMSeg ()
 {
     //over ride charmap
     CSphVector<CSphRemapRange> dRemaps;
-    dRemaps.Add ( CSphRemapRange ( 0x4e00, 0x9fff, 0x4e00 ) );
+    dRemaps.Add ( CSphRemapRange ( 0x4e00, 0x9FFF, 0x4e00 ) );
     dRemaps.Add ( CSphRemapRange ( 0xFF00, 0xFFFF, 0xFF00 ) );
-    dRemaps.Add ( CSphRemapRange ( 0x3000, 0x303F, 0x3000 ) );
+    dRemaps.Add ( CSphRemapRange ( 0x3000, 0x30FF, 0x3000 ) );
 
     CSphTokenizer_UTF8<IS_QUERY>::m_tLC.AddRemaps ( dRemaps,
         FLAG_CODEPOINT_NGRAM | FLAG_CODEPOINT_SPECIAL); // !COMMIT support other n-gram lengths than 1


### PR DESCRIPTION
This PR can make coreseek indexing Hiragana and Kataganas, together with existing CJK range to let coreseek compatible with Japanese.
